### PR TITLE
Remove neoclide/coc.nvim because of yarn related errors

### DIFF
--- a/rc/common/plug.vimrc
+++ b/rc/common/plug.vimrc
@@ -19,7 +19,7 @@ Plug 'hail2u/vim-css3-syntax'
 Plug 'honza/vim-snippets'
 Plug 'Lokaltog/vim-easymotion'
 Plug 'majutsushi/tagbar'
-Plug 'neoclide/coc.nvim', {'do': { -> coc#util#install()}}
+"Plug 'neoclide/coc.nvim', {'do': { -> coc#util#install()}}
 Plug 'roryokane/detectindent'
 Plug 'skammer/vim-css-color'
 Plug 'tmux-plugins/vim-tmux'


### PR DESCRIPTION
Error when launching nvim: `yarn: error: no such option: --frozen-lockfile`